### PR TITLE
Introduced configurable entry format

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ aggregates:
       input_dir: changelog
 ```
 
+### Templates
+
+The `templates` section in the `logchange-config.yml` configuration file allows you to customize the format of entries in the `changelog.md` file. Individual elements of an entry can include:  
+- `${prefix}` => `**Project_name** -` (used only with the `aggregate` command and specifies the project name from which the entry was pulled)  
+- `${title}` => `Description of the change`
+- `${merge_requests}` => `!1000`
+- `${issues}` => `#1234`
+- `${links}` => `[logchange](https://github.com/logchange/logchange)`
+- `${authors}` => `([Logchange team](https://github.com/orgs/logchange/teams/logchange-main-team) @logchange-main-team)`
+
 ### Generating `CHANGELOG.md`
 
 Everytime you want to generate `CHANGELOG.md` you can use command:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ changelog:
         update: Updated
       with_default_value: with default value
       description: Description
+  templates:
+    entry: "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}"
 aggregates:
   projects:
     - name: hofund

--- a/changelog/unreleased/0338-config-templates.yml
+++ b/changelog/unreleased/0338-config-templates.yml
@@ -1,7 +1,7 @@
 # This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
 # Visit https://github.com/logchange/logchange and leave a star 🌟
 # More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
-title: Ability to configure the entry format in the Changelog.md file.
+title: Added ability to configure the entry format in the Changelog.md file.
 authors:
   - name: Mateusz Witkowski
     nick: witx98

--- a/changelog/unreleased/0338-config-templates.yml
+++ b/changelog/unreleased/0338-config-templates.yml
@@ -9,5 +9,5 @@ authors:
 issues:
   - 338
 merge_requests:
-  - 000
+  - 351
 type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/changelog/unreleased/0338-config-templates.yml
+++ b/changelog/unreleased/0338-config-templates.yml
@@ -1,0 +1,13 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Ability to configure the entry format in the Changelog.md file.
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+issues:
+  - 338
+merge_requests:
+  - 000
+type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/logchange-core/src/main/java/dev/logchange/core/domain/config/model/Config.java
+++ b/logchange-core/src/main/java/dev/logchange/core/domain/config/model/Config.java
@@ -2,7 +2,7 @@ package dev.logchange.core.domain.config.model;
 
 import dev.logchange.core.domain.config.model.aggregate.Aggregates;
 import dev.logchange.core.domain.config.model.labels.Labels;
-import lombok.AccessLevel;
+import dev.logchange.core.domain.config.model.templates.Templates;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +16,12 @@ public class Config {
     public static final Config EMPTY = Config.builder()
             .heading(Heading.EMPTY)
             .labels(Labels.EMPTY)
+            .templates(Templates.EMPTY)
             .aggregates(Aggregates.EMPTY)
             .build();
 
     private Heading heading;
     private Labels labels;
-
+    private Templates templates;
     private Aggregates aggregates;
-
 }

--- a/logchange-core/src/main/java/dev/logchange/core/domain/config/model/templates/Templates.java
+++ b/logchange-core/src/main/java/dev/logchange/core/domain/config/model/templates/Templates.java
@@ -1,18 +1,15 @@
 package dev.logchange.core.domain.config.model.templates;
 
 
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.RequiredArgsConstructor;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 @Builder
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Templates {
 
+    public static final String DEFAULT_ENTRY_FORMAT = "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}";
     public static final Templates EMPTY = Templates.builder().build();
-    private static final String DEFAULT_ENTRY_FORMAT = "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}";
     private String entryFormat;
 
     public String getEntryFormat() {

--- a/logchange-core/src/main/java/dev/logchange/core/domain/config/model/templates/Templates.java
+++ b/logchange-core/src/main/java/dev/logchange/core/domain/config/model/templates/Templates.java
@@ -1,0 +1,21 @@
+package dev.logchange.core.domain.config.model.templates;
+
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Templates {
+
+    public static final Templates EMPTY = Templates.builder().build();
+    private static final String DEFAULT_ENTRY_FORMAT = "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}";
+    private String entryFormat;
+
+    public String getEntryFormat() {
+        return defaultIfBlank(entryFormat, DEFAULT_ENTRY_FORMAT);
+    }
+}

--- a/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/entry/MDChangelogEntry.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/entry/MDChangelogEntry.java
@@ -1,16 +1,16 @@
 package dev.logchange.core.format.md.changelog.entry;
 
 import dev.logchange.core.domain.changelog.model.entry.ChangelogEntry;
+import dev.logchange.core.domain.config.model.Config;
 import dev.logchange.core.format.md.MD;
+import dev.logchange.core.format.md.changelog.Configurable;
 import dev.logchange.md.list.MarkdownLists;
 import org.apache.commons.text.StringSubstitutor;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class MDChangelogEntry implements MD {
-
-    private static final String entryFormat = "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}";
+public class MDChangelogEntry extends Configurable implements MD {
 
     private final ChangelogEntry entry;
 
@@ -20,7 +20,8 @@ public class MDChangelogEntry implements MD {
     private final MDChangelogEntryLinks mdLinks;
     private final MDChangelogEntryAuthors mdAuthors;
 
-    public MDChangelogEntry(ChangelogEntry entry) {
+    public MDChangelogEntry(ChangelogEntry entry, Config config) {
+        super(config);
         this.entry = entry;
         this.prefix = MDChangelogEntryPrefix.of(entry.getPrefix());
         this.mdMergeRequests = new MDChangelogEntryMergeRequests(entry.getMergeRequests());
@@ -44,6 +45,7 @@ public class MDChangelogEntry implements MD {
         valuesMap.put("authors", mdAuthors.toMD());
 
         StringSubstitutor sub = new StringSubstitutor(valuesMap);
-        return sub.replace(entryFormat).replaceAll("\\s{2,}", " ");
+        return sub.replace(getConfig().getTemplates().getEntryFormat())
+                .replaceAll("\\s{2,}", " ");
     }
 }

--- a/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/version/MDChangelogEntriesGroup.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/version/MDChangelogEntriesGroup.java
@@ -41,7 +41,7 @@ class MDChangelogEntriesGroup extends Configurable implements MD {
         stringBuilder.append(getTypeHeading()).append("\n").append("\n");
 
         for (ChangelogEntry entry : entries) {
-            stringBuilder.append(new MDChangelogEntry(entry)).append("\n");
+            stringBuilder.append(new MDChangelogEntry(entry, getConfig())).append("\n");
         }
 
         return stringBuilder.append("\n").toString();

--- a/logchange-core/src/main/java/dev/logchange/core/format/yml/config/YMLChangelog.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/yml/config/YMLChangelog.java
@@ -1,11 +1,14 @@
 package dev.logchange.core.format.yml.config;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.logchange.core.domain.config.model.Config;
 import dev.logchange.core.domain.config.model.Heading;
 import dev.logchange.core.domain.config.model.labels.Labels;
+import dev.logchange.core.domain.config.model.templates.Templates;
 import dev.logchange.core.format.yml.config.labels.YMLLabels;
+import dev.logchange.core.format.yml.config.templates.YMLTemplates;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -23,10 +26,15 @@ public class YMLChangelog {
     @JsonProperty(index = 1)
     public YMLLabels labels;
 
+    @JsonProperty(index = 2)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public YMLTemplates templates;
+
     public static YMLChangelog of(Config config) {
         return YMLChangelog.builder()
                 .heading(config.getHeading().getValue())
                 .labels(YMLLabels.of(config.getLabels()))
+                .templates(YMLTemplates.of(config.getTemplates()))
                 .build();
     }
 
@@ -41,6 +49,13 @@ public class YMLChangelog {
         } else {
             return labels.to();
         }
+    }
+
+    public Templates toTemplates() {
+        if (templates == null) {
+            return Templates.EMPTY;
+        }
+        return templates.to();
     }
 
     public Heading toHeading() {

--- a/logchange-core/src/main/java/dev/logchange/core/format/yml/config/YMLConfig.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/yml/config/YMLConfig.java
@@ -8,6 +8,7 @@ import dev.logchange.core.domain.config.model.Config;
 import dev.logchange.core.domain.config.model.Heading;
 import dev.logchange.core.domain.config.model.aggregate.Aggregates;
 import dev.logchange.core.domain.config.model.labels.Labels;
+import dev.logchange.core.domain.config.model.templates.Templates;
 import dev.logchange.core.format.yml.ObjectMapperProvider;
 import dev.logchange.core.format.yml.config.aggregate.YMLAggregates;
 import lombok.AllArgsConstructor;
@@ -70,6 +71,7 @@ public class YMLConfig {
         return Config.builder()
                 .heading(toHeading())
                 .labels(toLabels())
+                .templates(toTemplates())
                 .aggregates(toAggregates())
                 .build();
     }
@@ -88,6 +90,13 @@ public class YMLConfig {
         } else {
             return changelog.toLabels();
         }
+    }
+
+    private Templates toTemplates() {
+        if (changelog == null) {
+            return Templates.EMPTY;
+        }
+        return changelog.toTemplates();
     }
 
 

--- a/logchange-core/src/main/java/dev/logchange/core/format/yml/config/templates/YMLTemplates.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/yml/config/templates/YMLTemplates.java
@@ -1,0 +1,32 @@
+package dev.logchange.core.format.yml.config.templates;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.logchange.core.domain.config.model.templates.Templates;
+import lombok.Builder;
+import lombok.extern.java.Log;
+
+@Log
+@Builder
+public class YMLTemplates {
+
+    @JsonProperty(index = 0)
+    public String entry;
+
+    public static YMLTemplates of(Templates templates) {
+        return YMLTemplates.builder()
+                .entry(templates.getEntryFormat())
+                .build();
+    }
+
+    @JsonAnySetter
+    public void anySetter(String key, Object value) {
+        log.warning("Unknown property: " + key + " with value " + value);
+    }
+
+    public Templates to() {
+        return Templates.builder()
+                .entryFormat(entry)
+                .build();
+    }
+}

--- a/logchange-core/src/main/java/dev/logchange/core/format/yml/config/templates/YMLTemplates.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/yml/config/templates/YMLTemplates.java
@@ -3,11 +3,15 @@ package dev.logchange.core.format.yml.config.templates;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.logchange.core.domain.config.model.templates.Templates;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.extern.java.Log;
 
 @Log
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class YMLTemplates {
 
     @JsonProperty(index = 0)

--- a/logchange-core/src/test/java/dev/logchange/core/domain/config/model/templates/TemplatesTest.java
+++ b/logchange-core/src/test/java/dev/logchange/core/domain/config/model/templates/TemplatesTest.java
@@ -1,0 +1,38 @@
+package dev.logchange.core.domain.config.model.templates;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static dev.logchange.core.domain.config.model.templates.Templates.DEFAULT_ENTRY_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TemplatesTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  "})
+    void shouldReturnDefaultEntryFormat(String value) {
+        // given:
+        Templates templates = Templates.builder().entryFormat(value).build();
+
+        // when:
+        String entryFormat = templates.getEntryFormat();
+        // then:
+        assertEquals(DEFAULT_ENTRY_FORMAT, entryFormat);
+    }
+
+    @Test
+    void shouldReturnProvidedEntryFormat() {
+        // given:
+        String expected_format = "${title} ${issues}";
+        Templates templates = Templates.builder().entryFormat(expected_format).build();
+
+        // when:
+        String entryFormat = templates.getEntryFormat();
+
+        // then:
+        assertEquals(expected_format, entryFormat);
+    }
+}

--- a/logchange-core/src/test/java/dev/logchange/core/format/md/changelog/entry/MDChangelogEntryTest.java
+++ b/logchange-core/src/test/java/dev/logchange/core/format/md/changelog/entry/MDChangelogEntryTest.java
@@ -1,6 +1,7 @@
 package dev.logchange.core.format.md.changelog.entry;
 
 import dev.logchange.core.domain.changelog.model.entry.*;
+import dev.logchange.core.domain.config.model.Config;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -15,7 +16,8 @@ class MDChangelogEntryTest {
         ChangelogEntry entry = getSomeEntry(null);
 
         //when:
-        String result = new MDChangelogEntry(entry).toString();
+
+        String result = new MDChangelogEntry(entry, Config.EMPTY).toString();
 
         //then:
         assertEquals("- Some Title !567 #890 [Some link](https//google.com) ([Some Name](https://nick.name) @Nick)", result);
@@ -27,8 +29,8 @@ class MDChangelogEntryTest {
         ChangelogEntry entry = getSomeEntry(null);
 
         //when:
-        String result1 = new MDChangelogEntry(entry).toString();
-        String result2 = new MDChangelogEntry(entry).toMD();
+        String result1 = new MDChangelogEntry(entry, Config.EMPTY).toString();
+        String result2 = new MDChangelogEntry(entry, Config.EMPTY).toMD();
 
         //then:
         assertEquals(result1, result2);
@@ -40,7 +42,7 @@ class MDChangelogEntryTest {
         ChangelogEntry entry = getSomeEntry("Some prefix");
 
         //when:
-        String result = new MDChangelogEntry(entry).toString();
+        String result = new MDChangelogEntry(entry, Config.EMPTY).toString();
 
         //then:
         assertEquals("- **Some prefix** - Some Title !567 #890 [Some link](https//google.com) ([Some Name](https://nick.name) @Nick)", result);
@@ -52,8 +54,8 @@ class MDChangelogEntryTest {
         ChangelogEntry entry = getSomeEntry("Some prefix");
 
         //when:
-        String result1 = new MDChangelogEntry(entry).toString();
-        String result2 = new MDChangelogEntry(entry).toMD();
+        String result1 = new MDChangelogEntry(entry, Config.EMPTY).toString();
+        String result2 = new MDChangelogEntry(entry, Config.EMPTY).toMD();
 
         //then:
         assertEquals(result1, result2);

--- a/logchange-core/src/test/resources/TwoConfigurationTypesIntegrationTest/EXPECTED_CUSTOM_CHANGELOG.md
+++ b/logchange-core/src/test/resources/TwoConfigurationTypesIntegrationTest/EXPECTED_CUSTOM_CHANGELOG.md
@@ -1,0 +1,42 @@
+<!-- @formatter:off -->
+<!-- noinspection -->
+<!-- Prevents auto format, for JetBrains IDE File > Settings > Editor > Code Style (Formatter Tab) > Turn formatter on/off with markers in code comments  -->
+
+<!-- This file is automatically generate by logchange tool 🌳 🪓 => 🪵 -->
+<!-- Visit https://github.com/logchange/logchange and leave a star 🌟 -->
+<!-- !!! ⚠️ DO NOT MODIFY THIS FILE, YOUR CHANGES WILL BE LOST ⚠️ !!! -->
+
+
+My heading
+
+
+[Not released]
+--------------
+
+### Important remarks
+
+- Update style.css on server during instalation 1
+- configuration
+- configuration
+- Update style.css on server during instalation 2
+
+### A (1 modification)
+
+- Test title 2 #1 !1
+
+### F (1 modification)
+
+- Test title 1 #1 !1 !2
+
+### Configuration modifications
+
+| Kind: database parameter                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <ul><li>Introduced `simpleparam.name.enabled` with predefined value: `true`</li><li>Summary: Enables displying feature name 1</li><li>You can put more information here, any text f.e !1 #1, even [link test](https://google.com)</li></ul> |
+
+| Kind: environment variable                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------------------------------- |
+| <ul><li>Introduced `simpleparam.name.enabled` with predefined value: `true`</li><li>Summary: Enables displying feature name 2</li></ul> |
+
+
+


### PR DESCRIPTION
## Issue: https://github.com/logchange/logchange/issues/338

## Result:
### logchange-config.yml
```yml
    templates:
        entry: "${prefix}${title} ${authors} ${links} ${issues} ${merge_requests}"
```

## Entry
```yml
title: Some change
authors:
  - name: Mateusz Witkowski
    nick: witx98
    url: https://github.com/witx98
issues:
  - 999
links:
  - name: Google
    url: https://google.com
merge_requests:
  - 1000
type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]
```

### CHANGELOG.md
```md
[unreleased]
------------

### Added (1 change)

- Some change ([Mateusz Witkowski](https://github.com/witx98) @witx98) [Google](https://google.com) #999 !1000

```