### PR TITLE
Fixed CLI exit code

### DIFF
--- a/changelog/unreleased/cli-exit-code.yml
+++ b/changelog/unreleased/cli-exit-code.yml
@@ -1,0 +1,11 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Fixed returned CLI exit code when application fails
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+merge_requests:
+  - xx
+type: fixed # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/changelog/unreleased/cli-exit-code.yml
+++ b/changelog/unreleased/cli-exit-code.yml
@@ -7,5 +7,5 @@ authors:
     nick: witx98
     url: https://github.com/witx98
 merge_requests:
-  - xx
+  - 392
 type: fixed # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/logchange-cli/src/main/java/dev/logchange/cli/BaseCommand.java
+++ b/logchange-cli/src/main/java/dev/logchange/cli/BaseCommand.java
@@ -18,10 +18,10 @@ public abstract class BaseCommand implements Runnable {
             if (verbose) {
                 LogchangeLogger.setLevel(LoggerLevel.DEBUG);
             }
-
             runCommand();
         } catch (Exception e) {
             log.debug(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/logchange-cli/src/main/java/dev/logchange/cli/LogchangeCliCommand.java
+++ b/logchange-cli/src/main/java/dev/logchange/cli/LogchangeCliCommand.java
@@ -32,8 +32,13 @@ public class LogchangeCliCommand implements Runnable {
 
     private static CommandLine commandLine;
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         commandLine = new CommandLine(new LogchangeCliCommand());
+        commandLine.setExecutionExceptionHandler((ex, cmd, parseResult) -> {
+            log.error(String.format("Command %s execution failed", cmd.getCommandName()));
+            log.error(ex.getMessage());
+            return 1;
+        });
         int exitCode = commandLine.execute(args);
         System.exit(exitCode);
     }

--- a/logchange-utils/src/main/java/dev/logchange/utils/logger/LogchangeLogger.java
+++ b/logchange-utils/src/main/java/dev/logchange/utils/logger/LogchangeLogger.java
@@ -12,13 +12,13 @@ public class LogchangeLogger {
 
     public void error(String msg) {
         if (level.isEnabled(LoggerLevel.ERROR)) {
-            System.out.println("[ERROR]" + msg);
+            System.out.println("[ERROR] " + msg);
         }
     }
 
     public void warn(String msg) {
         if (level.isEnabled(LoggerLevel.WARN)) {
-            System.out.println("[WARN]" + msg);
+            System.out.println("[WARN] " + msg);
         }
     }
 
@@ -30,7 +30,7 @@ public class LogchangeLogger {
 
     public void debug(String msg) {
         if (level.isEnabled(LoggerLevel.DEBUG)) {
-            System.out.println("[DEBUG]" + msg);
+            System.out.println("[DEBUG] " + msg);
         }
     }
 
@@ -41,7 +41,7 @@ public class LogchangeLogger {
 
     public void debug(Exception e) {
         if (level.isEnabled(LoggerLevel.DEBUG)) {
-            System.out.println("[DEBUG]" + e.getMessage());
+            System.out.println("[DEBUG] " + e.getMessage());
             e.printStackTrace(System.out);
         }
     }


### PR DESCRIPTION
Currently, the CLI always returns a success exit code `(0)` even when the application encounters a failure. This behavior occurs because all exceptions are caught without propagating them. In CI/CD pipelines, the success or failure of a job is determined by the exit code of the executed command. A success exit code `(0)` misleads the pipeline into marking the job as passed, even if the application encountered errors.