### PR TITLE
Added possibility to include author name, nick and URL information in batch mode options --author and --authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,19 +375,19 @@ TODO
 
 ### logchange add
 
-| Option                   | Default Value | Description                                                      |
-|--------------------------|---------------|------------------------------------------------------------------|
-| `--inputDir`             | `changelog`   | Specifies the input directory for the logchange data.            |
-| `--unreleasedVersionDir` | `unreleased`  | Specifies the directory where created entries will be stored.    |
-| `--fileName`             | N/A           | The name of the entry file.                                      |
-| `--batchMode`            | `false`       | Determines if the command should run in batch mode.              |
-| `--empty`                | `false`       | Allows adding an empty entry.                                    |
-| `--title`                | N/A           | The title of the CHANGELOG entry.                                |
-| `--author`               | N/A           | The author of the change, assigned to the CHANGELOG entry.       |
-| `--authors`              | N/A           | List of authors, separated by commas.                            |
-| `--type`                 | N/A           | The type of change (e.g., "added", "changed", etc.).             |
-| `--link.name`            | N/A           | The name of the link to be included in the change description.   |
-| `--link.url`             | N/A           | The URL associated with the link, such as a bug report or issue. |
+| Option                   | Default Value | Description                                                                                                                                                                                                                            |
+|--------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--inputDir`             | `changelog`   | Specifies the input directory for the logchange data.                                                                                                                                                                                  |
+| `--unreleasedVersionDir` | `unreleased`  | Specifies the directory where created entries will be stored.                                                                                                                                                                          |
+| `--fileName`             | N/A           | The name of the entry file.                                                                                                                                                                                                            |
+| `--batchMode`            | `false`       | Determines if the command should run in batch mode.                                                                                                                                                                                    |
+| `--empty`                | `false`       | Allows adding an empty entry.                                                                                                                                                                                                          |
+| `--title`                | N/A           | The title of the CHANGELOG entry.                                                                                                                                                                                                      |
+| `--author`               | N/A           | The author of the change, assigned to the CHANGELOG entry. The value should follow the format: `"name; nick; url"`, with fields separated by the `;` character.                                                                        |
+| `--authors`              | N/A           | A list of authors, separated by commas. For each author, the same format as in the `--author` option applies, e.g., `"John Doe; jdoe; https://github.com/logchange/hofund, Richard Roe; rroe; https://github.com/logchange/valhalla"`. |
+| `--type`                 | N/A           | The type of change (e.g., "added", "changed", etc.).                                                                                                                                                                                   |
+| `--link.name`            | N/A           | The name of the link to be included in the change description.                                                                                                                                                                         |
+| `--link.url`             | N/A           | The URL associated with the link, such as a bug report or issue.                                                                                                                                                                       |
 
 
 ### logchange generate

--- a/changelog/unreleased/0413-author-nick-url-option.yml
+++ b/changelog/unreleased/0413-author-nick-url-option.yml
@@ -1,0 +1,11 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Added possibility to include author name, nick and url information in batch mode options --author and --authors
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+merge_requests:
+  - 413
+type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/logchange-commands/src/main/java/dev/logchange/commands/add/BatchModeChangelogEntryProvider.java
+++ b/logchange-commands/src/main/java/dev/logchange/commands/add/BatchModeChangelogEntryProvider.java
@@ -43,13 +43,13 @@ public class BatchModeChangelogEntryProvider implements ChangelogEntryProvider {
         List<String> authors = params.getAuthors();
         if (authors != null && !authors.isEmpty()) {
             return authors.stream()
-                    .map(a -> ChangelogEntryAuthor.of("", a.trim(), ""))
+                    .map(a -> ChangelogEntryAuthor.of(a.trim()))
                     .collect(Collectors.toList());
         }
 
         String author = params.getAuthor();
         if (StringUtils.isNotBlank(author)) {
-            return Collections.singletonList(ChangelogEntryAuthor.of("", author.trim(), ""));
+            return Collections.singletonList(ChangelogEntryAuthor.of(author.trim()));
         }
 
         return Collections.emptyList();

--- a/logchange-commands/src/main/java/dev/logchange/commands/add/UserInputChangelogEntryProvider.java
+++ b/logchange-commands/src/main/java/dev/logchange/commands/add/UserInputChangelogEntryProvider.java
@@ -142,10 +142,10 @@ class UserInputChangelogEntryProvider implements ChangelogEntryProvider {
         List<String> authorsList = batchModeParams.getAuthors();
         if (StringUtils.isNotBlank(author) || (authorsList != null && !authorsList.isEmpty())) {
             if (StringUtils.isNotBlank(author)) {
-                return Collections.singletonList(ChangelogEntryAuthor.of("", author.trim(), ""));
+                return Collections.singletonList(ChangelogEntryAuthor.of(author.trim()));
             } else {
                 return authorsList.stream()
-                        .map(a -> ChangelogEntryAuthor.of("", a.trim(), ""))
+                        .map(a -> ChangelogEntryAuthor.of(a.trim()))
                         .collect(Collectors.toList());
             }
         }

--- a/logchange-commands/src/test/java/dev/logchange/commands/add/BatchModeChangelogEntryProviderTest.java
+++ b/logchange-commands/src/test/java/dev/logchange/commands/add/BatchModeChangelogEntryProviderTest.java
@@ -33,7 +33,9 @@ class BatchModeChangelogEntryProviderTest {
 
         // then:
         assertEquals(1, changelogEntry.getAuthors().size());
-        assertEquals("Peter", changelogEntry.getAuthors().get(0).getNick());
+        assertEquals("Peter", changelogEntry.getAuthors().get(0).getName());
+        assertEquals("", changelogEntry.getAuthors().get(0).getNick());
+        assertEquals("", changelogEntry.getAuthors().get(0).getUrl());
     }
 
     @Test
@@ -46,7 +48,7 @@ class BatchModeChangelogEntryProviderTest {
 
         // then:
         assertEquals(2, authors.size());
-        assertEquals("Peter", authors.get(0).getNick());
-        assertEquals("Matthew", authors.get(1).getNick());
+        assertEquals("Peter", authors.get(0).getName());
+        assertEquals("Matthew", authors.get(1).getName());
     }
 }

--- a/logchange-core/src/main/java/dev/logchange/core/domain/changelog/model/entry/ChangelogEntryAuthor.java
+++ b/logchange-core/src/main/java/dev/logchange/core/domain/changelog/model/entry/ChangelogEntryAuthor.java
@@ -34,4 +34,17 @@ public class ChangelogEntryAuthor {
         return new ChangelogEntryAuthor(name, nick, url);
     }
 
+    public static ChangelogEntryAuthor of(String author) {
+        if (StringUtils.isBlank(author)) {
+            throw new IllegalArgumentException("Cannot create blank author");
+        }
+        String[] authorParts = author.split(";");
+
+        String name = (authorParts.length > 0 ? authorParts[0] : "").trim();
+        String nick = (authorParts.length > 1 ? authorParts[1] : "").trim();
+        String url = (authorParts.length > 2 ? authorParts[2] : "").trim();
+
+        return ChangelogEntryAuthor.of(name, nick, url);
+    }
+
 }

--- a/logchange-core/src/test/java/dev/logchange/core/domain/changelog/model/entry/ChangelogEntryAuthorTest.java
+++ b/logchange-core/src/test/java/dev/logchange/core/domain/changelog/model/entry/ChangelogEntryAuthorTest.java
@@ -1,6 +1,8 @@
 package dev.logchange.core.domain.changelog.model.entry;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -82,4 +84,75 @@ class ChangelogEntryAuthorTest {
         assertEquals("", author.getUrl());
     }
 
+    @Test
+    void givenOnlyName_shouldCreateAuthorWithCorrectNameAndBlankNickAndUrl() {
+        // given:
+        String input = " John doe ";
+        String expected = "John doe";
+
+        // when
+        ChangelogEntryAuthor changelogEntryAuthor = ChangelogEntryAuthor.of(input);
+
+        // then:
+        assertEquals(expected, changelogEntryAuthor.getName());
+        assertEquals("", changelogEntryAuthor.getNick());
+        assertEquals("", changelogEntryAuthor.getUrl());
+    }
+
+    @Test
+    void givenOnlyNick_shouldCreateAuthorWithCorrectNickAndBlankNameAndUrl() {
+        // given:
+        String input = "; jdoe ";
+        String expected = "jdoe";
+
+        // when
+        ChangelogEntryAuthor changelogEntryAuthor = ChangelogEntryAuthor.of(input);
+
+        // then:
+        assertEquals("", changelogEntryAuthor.getName());
+        assertEquals(expected, changelogEntryAuthor.getNick());
+        assertEquals("", changelogEntryAuthor.getUrl());
+    }
+
+    @Test
+    void givenOnlyUrl_shouldCreateAuthorWithCorrectUrlAndBlankNameAndNick() {
+        // given:
+        String input = "; ; https://github.com/logchange ";
+        String expected = "https://github.com/logchange";
+
+        // when
+        ChangelogEntryAuthor changelogEntryAuthor = ChangelogEntryAuthor.of(input);
+
+        // then:
+        assertEquals("", changelogEntryAuthor.getName());
+        assertEquals("", changelogEntryAuthor.getNick());
+        assertEquals(expected, changelogEntryAuthor.getUrl());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void givenBlankString_shouldThrowException(String input) {
+        // when
+        Exception ex = assertThrows(IllegalArgumentException.class, () ->ChangelogEntryAuthor.of(input));
+
+        // then:
+        assertEquals("Cannot create blank author", ex.getMessage());
+    }
+
+    @Test
+    void givenFullAuthorInformation_shouldFillAllObjectProperties() {
+        // given:
+        String input = "John Doe; jdoe; https://github.com/logchange ";
+        String expectedName = "John Doe";
+        String expectedNick = "jdoe";
+        String expectedURL = "https://github.com/logchange";
+
+        // when
+        ChangelogEntryAuthor changelogEntryAuthor = ChangelogEntryAuthor.of(input);
+
+        // then:
+        assertEquals(expectedName, changelogEntryAuthor.getName());
+        assertEquals(expectedNick, changelogEntryAuthor.getNick());
+        assertEquals(expectedURL, changelogEntryAuthor.getUrl());
+    }
 }

--- a/logchange-maven-plugin/src/test/java/dev/logchange/maven_plugin/mojo/add/AddChangelogEntryMojoIT.java
+++ b/logchange-maven-plugin/src/test/java/dev/logchange/maven_plugin/mojo/add/AddChangelogEntryMojoIT.java
@@ -44,7 +44,7 @@ class AddChangelogEntryMojoIT {
                 "# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅\uFE0F⬅ \uFE0F\n" +
                 "title: '\"Upgraded A from 1.0.0 to 2.0.0\"'\n" +
                 "authors:\n" +
-                "  - nick: marwin1991\n" +
+                "  - name: marwin1991\n" +
                 "links:\n" +
                 "  - name: notes\n" +
                 "    url: https://logchange.dev\n" +


### PR DESCRIPTION
@janhoy Here are the changes you mentioned in https://github.com/logchange/logchange/pull/408#pullrequestreview-2558373504.

Both `--author` and `--authors` now support specifying the name, nick, and URL:
```shell
--authors "John Doe; jdoe; https://github.com/logchange/hofund, Richard Roe; rroe; https://github.com/logchange/valhalla"
```

The output will be:
```yml
authors:
  - name: John Doe
    nick: jdoe
    url: https://github.com/logchange/hofund
  - name: Richard Roe
    nick: rroe
    url: https://github.com/logchange/valhalla
 ```
 
If you don't want to provide a specific field (e.g., nickname), just leave it empty:
 ```shell
 --authors "John Doe; ; https://github.com/logchange/hofund"
 ```
 
 @marwin1991 