### PR TITLE
Enable HTTP/HTTPS URL protocols in native image build

### DIFF
--- a/changelog/unreleased/0001-CLI-HTTP.yml
+++ b/changelog/unreleased/0001-CLI-HTTP.yml
@@ -7,5 +7,5 @@ authors:
     nick: witx98
     url: https://github.com/witx98
 merge_requests:
-  - 481
+  - 482
 type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/changelog/unreleased/0001-CLI-HTTP.yml
+++ b/changelog/unreleased/0001-CLI-HTTP.yml
@@ -1,0 +1,11 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Enabled HTTP/HTTPS URL protocols in native image build
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+merge_requests:
+  - 481
+type: added # [added/changed/deprecated/removed/fixed/security/dependency_update/other]

--- a/logchange-cli/pom.xml
+++ b/logchange-cli/pom.xml
@@ -215,6 +215,7 @@
                             <buildArgs>
                                 <arg>--initialize-at-build-time=org.xml.sax.helpers.LocatorImpl</arg>
                                 <arg>--initialize-at-build-time=org.xml.sax.helpers.AttributesImpl</arg>
+                                <arg>--enable-url-protocols=http,https</arg>
                             </buildArgs>
                             <imageName>logchange</imageName>
                         </configuration>
@@ -254,6 +255,7 @@
                                 <arg>--static</arg>
                                 <arg>--initialize-at-build-time=org.xml.sax.helpers.LocatorImpl</arg>
                                 <arg>--initialize-at-build-time=org.xml.sax.helpers.AttributesImpl</arg>
+                                <arg>--enable-url-protocols=http,https</arg>
                             </buildArgs>
                             <imageName>logchange</imageName>
                         </configuration>


### PR DESCRIPTION
```
logchange aggregate --aggregateVersion 25.1.0
Running aggregate command...
Apr 09, 2025 2:42:25 PM dev.logchange.commands.aggregate.AggregateVersionCommand execute
INFO: Started aggregating 25.1.0 version
Apr 09, 2025 2:42:25 PM dev.logchange.core.application.file.Dir create
WARNING: v25.1.0 already exists.
Apr 09, 2025 2:42:25 PM dev.logchange.core.application.changelog.service.aggregate.AggregateProjectsVersionService handle
INFO: Started aggregating command
Apr 09, 2025 2:42:25 PM dev.logchange.core.infrastructure.query.file.TarGzExtractor get
INFO: Starting download from URL: https://github.com/logchange/hofund/archive/refs/heads/master.tar.gz
Apr 09, 2025 2:42:25 PM dev.logchange.core.infrastructure.query.file.TarGzExtractor get
INFO: Starting download from URL: https://github.com/logchange/logchange/archive/refs/heads/main.tar.gz
Apr 09, 2025 2:42:25 PM dev.logchange.commands.aggregate.AggregateVersionCommand execute
INFO: Deleting tmp directory
Apr 09, 2025 2:42:25 PM dev.logchange.core.application.file.Dir delete
INFO: Directory /tmp/tmp9479871521167993671 deleted.
[ERROR] Command aggregate execution failed
[ERROR] dev.logchange.core.application.changelog.service.aggregate.YMLAggregationException: Errors found:
Accessing a URL protocol that was not enabled. The URL protocol https is supported but not enabled by default. It must be enabled by adding the --enable-url-protocols=https option to the native-image command.
Accessing a URL protocol that was not enabled. The URL protocol https is supported but not enabled by default. It must be enabled by adding the --enable-url-protocols=https option to the native-image command.
