### PR TITLE
Support for versioned unreleased directories during generate

### DIFF
--- a/logchange-commands/src/test/java/dev/logchange/commands/generate/GenerateProjectCommandTest.java
+++ b/logchange-commands/src/test/java/dev/logchange/commands/generate/GenerateProjectCommandTest.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,6 +19,7 @@ class GenerateProjectCommandTest {
     private static final String PATH = "src/test/resources/GenerateProjectCommandTest";
     private static final String INPUT_DIR = "changelog";
     private static final String UNRELEASED = "unreleased/";
+    private static final String UNRELEASED_VERSIONED = "unreleased-1.2.3/";
     private static final String CONFIG_FILE = "logchange-config.yml";
     private static final String TEST_FILE = "test-entry.yml";
     private static final String OUTPUT_FILE = "CHANGELOG.md";
@@ -23,48 +28,88 @@ class GenerateProjectCommandTest {
     void onlyUnreleasedDir() throws IOException {
         // given:
         String TEST_PATH = PATH + "/onlyUnreleasedDir";
-        File entry = new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED + "/" + TEST_FILE);
-        File outputFile = new File(TEST_PATH + "/" + OUTPUT_FILE);
-        File expectedChangelog = new File(TEST_PATH + "/" + "EXPECTED_CHANGELOG.md");
-        assertTrue(entry.exists());
-        assertFalse(outputFile.exists());
-        assertTrue(expectedChangelog.exists());
+        try {
+            // given:
+            File entry = new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED + "/" + TEST_FILE);
+            File outputFile = new File(TEST_PATH + "/" + OUTPUT_FILE);
+            File expectedChangelog = new File(TEST_PATH + "/" + "EXPECTED_CHANGELOG.md");
+            assertTrue(entry.exists());
+            assertFalse(outputFile.exists());
+            assertTrue(expectedChangelog.exists());
 
-        // when:
-        GenerateProjectCommand.of(TEST_PATH, INPUT_DIR, TEST_PATH + "/" + OUTPUT_FILE, CONFIG_FILE).execute(false);
+            // when:
+            GenerateProjectCommand.of(TEST_PATH, INPUT_DIR, TEST_PATH + "/" + OUTPUT_FILE, CONFIG_FILE).execute(false);
 
-        // then:
-        assertTrue(outputFile.exists());
-        String expectedContent = FileUtils.fileRead(expectedChangelog, "UTF-8");
-        String actualContent = FileUtils.fileRead(outputFile, "UTF-8");
-        assertThat(actualContent).isEqualToIgnoringWhitespace(expectedContent);
-
-        // cleanup:
-        new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED + "/" + "version-summary.md").delete();
-        new File(TEST_PATH + "/" + OUTPUT_FILE).delete();
+            // then:
+            assertTrue(outputFile.exists());
+            String expectedContent = FileUtils.fileRead(expectedChangelog, "UTF-8");
+            String actualContent = FileUtils.fileRead(outputFile, "UTF-8");
+            assertThat(actualContent).isEqualToIgnoringWhitespace(expectedContent);
+        } finally {
+            cleanupMarkdownFiles(Paths.get(TEST_PATH));
+        }
     }
 
     @Test
     void missingReleaseDateTxt() throws IOException {
         // given:
         String TEST_PATH = PATH + "/missingReleaseDateTxt";
-        File entry = new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED + "/" + TEST_FILE);
-        File outputFile = new File(TEST_PATH + "/" + OUTPUT_FILE);
-        File expectedChangelog = new File(TEST_PATH + "/" + "EXPECTED_CHANGELOG.md");
-        assertTrue(entry.exists());
-        assertFalse(outputFile.exists());
-        assertTrue(expectedChangelog.exists());
+        try {
+            // given:
+            File entry = new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED + "/" + TEST_FILE);
+            File outputFile = new File(TEST_PATH + "/" + OUTPUT_FILE);
+            File expectedChangelog = new File(TEST_PATH + "/" + "EXPECTED_CHANGELOG.md");
+            assertTrue(entry.exists());
+            assertFalse(outputFile.exists());
+            assertTrue(expectedChangelog.exists());
 
-        // when:
-        GenerateProjectCommand.of(TEST_PATH, INPUT_DIR, TEST_PATH + "/" + OUTPUT_FILE, CONFIG_FILE).execute(false);
+            // when:
+            GenerateProjectCommand.of(TEST_PATH, INPUT_DIR, TEST_PATH + "/" + OUTPUT_FILE, CONFIG_FILE).execute(false);
 
-        // then:
-        assertTrue(outputFile.exists());
-        String expectedContent = FileUtils.fileRead(expectedChangelog, "UTF-8");
-        String actualContent = FileUtils.fileRead(outputFile, "UTF-8");
-        assertThat(actualContent).isEqualToIgnoringWhitespace(expectedContent);
+            // then:
+            assertTrue(outputFile.exists());
+            String expectedContent = FileUtils.fileRead(expectedChangelog, "UTF-8");
+            String actualContent = FileUtils.fileRead(outputFile, "UTF-8");
+            assertThat(actualContent).isEqualToIgnoringWhitespace(expectedContent);
+        } finally {
+            cleanupMarkdownFiles(Paths.get(TEST_PATH));
+        }
+    }
 
-        // cleanup:
-        new File(TEST_PATH + "/" + OUTPUT_FILE).delete();
+    @Test
+    void versionedUnreleasedDir() throws IOException {
+        String TEST_PATH = PATH + "/versionedUnreleasedDir";
+        try {
+            // given:
+            File entry = new File(TEST_PATH + "/" + INPUT_DIR + "/" + UNRELEASED_VERSIONED + "/" + TEST_FILE);
+            File outputFile = new File(TEST_PATH + "/" + OUTPUT_FILE);
+            File expectedChangelog = new File(TEST_PATH + "/" + "EXPECTED_CHANGELOG.md");
+            assertTrue(entry.exists());
+            assertFalse(outputFile.exists());
+            assertTrue(expectedChangelog.exists());
+
+            // when:
+            GenerateProjectCommand.of(TEST_PATH, INPUT_DIR, TEST_PATH + "/" + OUTPUT_FILE, CONFIG_FILE).execute(false);
+
+            // then:
+            assertTrue(outputFile.exists());
+            String expectedContent = FileUtils.fileRead(expectedChangelog, "UTF-8");
+            String actualContent = FileUtils.fileRead(outputFile, "UTF-8");
+            assertThat(actualContent).isEqualToIgnoringWhitespace(expectedContent);
+        } finally {
+            cleanupMarkdownFiles(Paths.get(TEST_PATH));
+        }
+    }
+
+    private void cleanupMarkdownFiles(Path outputDir) throws IOException {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(outputDir, "*.md")) {
+            for (Path file : stream) {
+                if (file.endsWith("EXPECTED_CHANGELOG.md")) {
+                    continue;
+                }
+                System.out.println("Deleting file: " + file);
+                Files.delete(file);
+            }
+        }
     }
 }

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/EXPECTED_CHANGELOG.md
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/EXPECTED_CHANGELOG.md
@@ -1,0 +1,82 @@
+<!-- @formatter:off -->
+<!-- noinspection -->
+<!-- Prevents auto format, for JetBrains IDE File > Settings > Editor > Code Style (Formatter Tab) > Turn formatter on/off with markers in code comments  -->
+
+<!-- This file is automatically generate by logchange tool 🌳 🪓 => 🪵 -->
+<!-- Visit https://github.com/logchange/logchange and leave a star 🌟 -->
+<!-- !!! ⚠️ DO NOT MODIFY THIS FILE, YOUR CHANGES WILL BE LOST ⚠️ !!! -->
+
+
+[Not Released]
+--------------
+
+### Important notes
+
+- important note
+
+### Added (1 change)
+
+- title !1000 #100 [name](url) ([NAME](URL) @NICK)
+
+### Configuration changes
+
+| Type: type                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------ |
+| <ul><li>Added `key` with default value: `defaultValue`</li><li>Description: description</li><li>moreInfo</li></ul> |
+
+
+[Not Released 1.9.0]
+--------------------
+
+### Important notes
+
+- important note
+
+### Added (1 change)
+
+- title !1000 #100 [name](url) ([NAME](URL) @NICK)
+
+### Configuration changes
+
+| Type: type                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------ |
+| <ul><li>Added `key` with default value: `defaultValue`</li><li>Description: description</li><li>moreInfo</li></ul> |
+
+
+[Not Released 1.2.3]
+--------------------
+
+### Important notes
+
+- important note
+
+### Added (1 change)
+
+- title !1000 #100 [name](url) ([NAME](URL) @NICK)
+
+### Configuration changes
+
+| Type: type                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------ |
+| <ul><li>Added `key` with default value: `defaultValue`</li><li>Description: description</li><li>moreInfo</li></ul> |
+
+
+[1.0.0]
+-------
+
+### Important notes
+
+- important note
+
+### Added (1 change)
+
+- title !1000 #100 [name](url) ([NAME](URL) @NICK)
+
+### Configuration changes
+
+| Type: type                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------ |
+| <ul><li>Added `key` with default value: `defaultValue`</li><li>Description: description</li><li>moreInfo</li></ul> |
+
+
+

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/logchange-config.yml
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/logchange-config.yml
@@ -1,0 +1,31 @@
+# This file configures logchange tool 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#configuration 
+changelog:
+  heading: ""
+  labels:
+    unreleased: Not Released
+    important_notes: Important notes
+    types:
+      added: Added
+      changed: Changed
+      deprecated: Deprecated
+      removed: Removed
+      fixed: Fixed
+      security: Security
+      dependency_update: Dependency updates
+      other: Security
+      number_of_changes:
+        singular: change
+        plural: changes
+    configuration:
+      heading: Configuration changes
+      type: Type
+      actions:
+        add: Added
+        update: Updated
+        delete: Deleted
+      with_default_value: with default value
+      description: Description
+  templates:
+    entry: "${prefix}${title} ${merge_requests} ${issues} ${links} ${authors}"

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased-1.2.3/test-entry.yml
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased-1.2.3/test-entry.yml
@@ -1,0 +1,26 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: title
+authors:
+  - name: NAME
+    nick: NICK
+    url: URL
+merge_requests:
+  - 1000
+issues:
+  - 100
+links:
+  - name: name
+    url: url
+type: added
+important_notes:
+  - important note
+configurations:
+  - type: type
+    action: add
+    key: key
+    default_value: defaultValue
+    description: description
+    more_info: moreInfo
+

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased-1.9.0/test-entry.yml
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased-1.9.0/test-entry.yml
@@ -1,0 +1,26 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: title
+authors:
+  - name: NAME
+    nick: NICK
+    url: URL
+merge_requests:
+  - 1000
+issues:
+  - 100
+links:
+  - name: name
+    url: url
+type: added
+important_notes:
+  - important note
+configurations:
+  - type: type
+    action: add
+    key: key
+    default_value: defaultValue
+    description: description
+    more_info: moreInfo
+

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased/test-entry.yml
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/unreleased/test-entry.yml
@@ -1,0 +1,26 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: title
+authors:
+  - name: NAME
+    nick: NICK
+    url: URL
+merge_requests:
+  - 1000
+issues:
+  - 100
+links:
+  - name: name
+    url: url
+type: added
+important_notes:
+  - important note
+configurations:
+  - type: type
+    action: add
+    key: key
+    default_value: defaultValue
+    description: description
+    more_info: moreInfo
+

--- a/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/v1.0.0/test-entry.yml
+++ b/logchange-commands/src/test/resources/GenerateProjectCommandTest/versionedUnreleasedDir/changelog/v1.0.0/test-entry.yml
@@ -1,0 +1,26 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵
+# Visit https://github.com/logchange/logchange and leave a star 🌟
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: title
+authors:
+  - name: NAME
+    nick: NICK
+    url: URL
+merge_requests:
+  - 1000
+issues:
+  - 100
+links:
+  - name: name
+    url: url
+type: added
+important_notes:
+  - important note
+configurations:
+  - type: type
+    action: add
+    key: key
+    default_value: defaultValue
+    description: description
+    more_info: moreInfo
+

--- a/logchange-core/src/main/java/dev/logchange/core/domain/changelog/model/version/Version.java
+++ b/logchange-core/src/main/java/dev/logchange/core/domain/changelog/model/version/Version.java
@@ -29,11 +29,18 @@ public class Version implements Comparable<Version> {
 
     @Override
     public int compareTo(Version other) {
-        if (UNRELEASED.equals(value)) {
+        if (isUnreleased() && other.isUnreleased()) {
+            if (UNRELEASED.equals(value)) {
+              return 1;
+            }
+            return this.value.compareTo(other.value);
+        }
+
+        if (isUnreleased()) {
             return 1;
         }
 
-        if (UNRELEASED.equals(other.value)) {
+        if (other.isUnreleased()) {
             return -1;
         }
 
@@ -50,7 +57,7 @@ public class Version implements Comparable<Version> {
     }
 
     public String getDirName() {
-        if (UNRELEASED.equals(value)) {
+        if (isUnreleased()) {
             return value;
         } else {
             return "v" + value;
@@ -58,7 +65,7 @@ public class Version implements Comparable<Version> {
     }
 
     public boolean isUnreleased() {
-        return UNRELEASED.equals(value);
+        return value.startsWith(UNRELEASED);
     }
 
     @Override

--- a/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/version/MDChangelogVersionHeading.java
+++ b/logchange-core/src/main/java/dev/logchange/core/format/md/changelog/version/MDChangelogVersionHeading.java
@@ -37,7 +37,12 @@ class MDChangelogVersionHeading extends Configurable implements MD {
     private String getVersionHeading() {
         Map<String, String> valuesMap = new HashMap<>();
         if (version.isUnreleased()) {
-            valuesMap.put("version", getConfig().getLabels().getUnreleased());
+            String[] prefixAndVersion = version.getValue().split("-");
+            if (prefixAndVersion.length > 1) {
+                valuesMap.put("version", getConfig().getLabels().getUnreleased() + " " + prefixAndVersion[1]);
+            } else {
+                valuesMap.put("version", getConfig().getLabels().getUnreleased());
+            }
         } else {
             valuesMap.put("version", version.getValue());
         }


### PR DESCRIPTION
Fixed #533 

We make the Version class understand `unreleased-*` and handles comparison so that unversioned section comes first, then sorted by version.

I also made the header use the configurable label in place of the `unreleased-` prefix.

A new test validates that it works and that three different unreleased-NN folders all end up in the CHANGELOG.md as expected.