### PR TITLE
Update reflect-config.json - reflect-config-generator.py was not run

### DIFF
--- a/logchange-cli/src/main/resources/META-INF/native-image/logchange-cli/reflect-config.json
+++ b/logchange-cli/src/main/resources/META-INF/native-image/logchange-cli/reflect-config.json
@@ -66,6 +66,12 @@
     "allDeclaredConstructors": true
   },
   {
+    "name": "dev.logchange.core.format.yml.changelog.entry.YMLChangelogModule",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
     "name": "dev.logchange.core.format.yml.config.YMLChangelog",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
This caused `logchange generate` to fail with `.yml` files having `modules:` even though it passed the tests.

The error was:

```
        Cannot construct instance of `dev.logchange.core.format.yml.changelog.entry.YMLChangelogModule` (n
o Creators, like default constructor, exist): no String-argument constructor/factory method to deserialize
 from String value ('foo')
 at [Source: (FileInputStream); line: 10, column: 5] (through reference chain: dev.logchange.core.format.y
ml.changelog.entry.YMLChangelogEntry["modules"]->java.util.ArrayList[0])
```