### PR TITLE
Fix a path concatenation bug

### DIFF
--- a/logchange-core/src/main/java/dev/logchange/core/infrastructure/persistance/changelog/FileChangelogRepository.java
+++ b/logchange-core/src/main/java/dev/logchange/core/infrastructure/persistance/changelog/FileChangelogRepository.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -109,7 +110,7 @@ public class FileChangelogRepository implements ChangelogRepository {
     }
 
     private void saveToFile(String content, String fileName) {
-        String outputFilePath = rootPath + fileName;
+        String outputFilePath = Paths.get(rootPath, fileName).toString();
         File outputFile = new File(outputFilePath);
 
         FileRepository fileRepository = FileRepository.of(outputFile);


### PR DESCRIPTION
I define a `changelog.templates.changelog_templates` with name `CHANGELOG.md`, to define the main changelog file in Jinja. However, the file that is written has a `.` prefix.

Here is a bug fix. Turned out to be a string concatenation bug.

TIP: Use `Path`, `Paths`, `Files` classes to compute paths, also to get it platform independent

(No issue created)