### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,6 @@
 name: Create release and Publish to DockerHub
+permissions:
+  contents: read
 
 on:
   push:
@@ -69,6 +71,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/logchange/logchange/security/code-scanning/1](https://github.com/logchange/logchange/security/code-scanning/1)

The issue is that jobs in `.github/workflows/create-release.yml` lack explicit `permissions` keys, leading to potentially excessive privileges being granted to the `GITHUB_TOKEN`. The best fix is to explicitly set the `permissions` either at the root of the workflow file (for all jobs), or individually per job (overriding the root value if needed). This should be set to the minimum needed for correct execution. For jobs that only require read access to repository contents, set `contents: read`. If a job needs to create releases or modify pull requests (such as in the `create-release` job), allow only the required permissions (e.g., `contents: write` for releases). 

The recommended starting point is to add a root-level `permissions` block—e.g., `permissions: contents: read`—to restrict default permissions for all jobs. Then, for jobs that strictly require greater privileges, raise those only as necessary by setting a job-level `permissions` key.

Specifically:
- Add a `permissions` block after the `name:` and before `on:` lines at the root of the workflow. This block should set `contents: read` as a minimal safe default.
- If the `create-release` job requires write permission (because it creates GitHub releases), add a job-level `permissions` block with `contents: write` to that job, so it can upload release assets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
